### PR TITLE
Add a warning for ravenkeeper+lycanthrope

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -282,7 +282,7 @@
 	"present": [["vigormortis"], ["poisoner"], ["poppy_grower", "poppygrower"]],
 	"warning": "Vigormortis killed Poisoner in a Poppy Grower game may poison the Vigormortis, creating an infinite poison loop."
   },
-    {
+  {
     "present": [["lunatic"], ["marionette"]],
     "warning": "The Marionette cannot \"think\" they are the Lunatic."
   },
@@ -293,5 +293,9 @@
   {
 	"present": [["king"], ["choirboy"], ["marionette"]],
 	"warning": "The Marionette cannot be the King added by the Choirboy"
+  },
+  {
+	"present": [["lycanthrope"], ["ravenkeeper"]],
+	"warning": "The Lycanthrope can exploit the Ravenkeeper's ability"
   }
 ]


### PR DESCRIPTION
Having the Lycanthrope in play, the Ravenkeeper can publicly disclose himself to be killed during the night to learn a role. 

This should be balanced with more poisoning (or killing) roles.