### PR TITLE
Damsel Jinx Update

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -82,7 +82,7 @@
   },
   {
     "present": [["spy", "widow"], ["#musthide"]],
-    "error": "Heretic, Damsel, and Choirboy don't work with characters that can see the Grimoire."
+    "error": "Heretic, and Choirboy don't work with characters that can see the Grimoire."
   },
   {
 	"present": [["choirboy"]],


### PR DESCRIPTION
Damsel is now poisoned if Spy/Widow in the game, so do not need the error for that anymore.