### PR TITLE
restore html controls for drag and drop

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,10 @@
       </p>
       <p>Blood on the Clocktower is a trademark of Steven Medway and The Pandemonium Institute.</p>
 
-      <input type="file" accept=".json" id="scriptUpload" />
+      <div class="drop-or-paste" tabindex="0">
+        <p>Drop file here or paste JSON anywhere</p>
+        <input type="file" accept=".json" id="scriptUpload">
+      </div>
 
       <ul id="returnList"></ul>
     </main>


### PR DESCRIPTION
I think the html needed for drag-and-drop got lost when #9 was merged before #8.