### PR TITLE
Rules for engineer and philosopher obvious choices

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -338,5 +338,13 @@
 	"present": [["legion"], ["slayer"]],
 	"missing": [["scarletwoman", "scarlet_woman", "recluse", "tinker", "harpy"]],
 	"warning": "A Slayer shot that doesn't end the game confirms Legion."
+  },
+  {
+    "present": [["engineer"], ["baron"]],
+    "warning": "Engineer can choose useless minion after setup"
+  },
+  {
+    "present": [["philosopher"], ["village_idiot", "villageidiot"]],
+    "warning": "Village idiot is nearly always the strongest role for philosopher"
   }
  ]


### PR DESCRIPTION
These two rules seek to address situations where a townsfolk gets to choose a character on the script and the choice is quite obvious due to poor interactions.
**Engineer and Baron**
There is no reason for a engineer to use their ability and not choose baron if it is on the script, it simply removes the ability from one of the minions
**Philosopher and Village idiot**
The village idiot is the strongest info role in the game along with the bounty hunter, but they both come with hefty drawbacks to balance them. When a philosopher gets to choose to become a village idiot they know for a fact they cannot be drunk to their own ability and thus sidestepping the main drawback. This is a possibly unfun interaction and script builders should be warned about it.